### PR TITLE
IRGen: treat global var as memory locations

### DIFF
--- a/design/lang.hrml
+++ b/design/lang.hrml
@@ -14,10 +14,11 @@ sub start()
             r = mul2(i1);
             outbox(r);
             if (i1 > 0) {
-                outbox(r);
+                outbox(r + glbvar);
             }
             floor[1] = r;
         } else {
+            glbvar = glbvar + i2;
             r = i2;
             outbox(r);
             floor[0] = r;


### PR DESCRIPTION
Treat global var as memory:
- Assignment checks the var operand reg id, if is global, store it to mem
- Access checks if the var operand is global, and load it to temp register if it is